### PR TITLE
Declare check_context_linelimit

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -22,6 +22,7 @@ void		add_to_context(struct context *, struct context_line *);
 void		do_context_action(struct context *);
 
 void		check_context_timeout();
+void		check_context_linelimit();
 
 void		expand_context_action_macros(struct context *);
 


### PR DESCRIPTION
In the case of __STDC__, check_context_linelimit was given an implicit
declaration in logwatch.c which was incompatible with the definition
in context.c.